### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/testingbot/TestingBotReport/index.jelly
+++ b/src/main/resources/testingbot/TestingBotReport/index.jelly
@@ -2,7 +2,7 @@
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="TestingBot Report - ${it.parent.displayName}">
     <l:side-panel>
-      <l:task href=".." title="${%Back To Test Result}" icon="images/24x24/up.gif" />
+      <l:task href=".." title="${%Back To Test Result}" icon="icon-up icon-md" />
     </l:side-panel>
     <l:main-panel>
         <h1>TestingBot Report</h1>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @delabiejochen
Thanks in advance!